### PR TITLE
Fix problem with 0.11 (and later) transport which might return integers ...

### DIFF
--- a/mod_slideshow.erl
+++ b/mod_slideshow.erl
@@ -82,8 +82,8 @@ observe_media_stillimage({media_stillimage, Id, _Props}, Context) ->
     
 %% @doc Handle a request for a slideshow popup
 observe_postback_notify(#postback_notify{message="slideshow"}, Context) ->
-    Ids = [ list_to_integer(Id) || Id <- z_context:get_q_all("id", Context) ],
-    Ids1 = [ Id || Id <- Ids, z_acl:rsc_visible(Id, Context) ],
+    Ids = [ z_convert:to_integer(Id) || Id <- z_context:get_q_all("id", Context) ],
+    Ids1 = [ Id || Id <- Ids, is_integer(Id), z_acl:rsc_visible(Id, Context) ],
     StartId = case z_context:get_q("start_id", Context) of
                 [] -> undefined;
                 QStartId -> list_to_integer(QStartId)
@@ -97,8 +97,7 @@ observe_postback_notify(#postback_notify{message="slideshow"}, Context) ->
                         {height, 600}
                     ],
                     Context);
-observe_postback_notify(X, _Context) ->
-    ?DEBUG(X),
+observe_postback_notify(_X, _Context) ->
     undefined.
 
     reorder_ids(undefined, Ids) ->


### PR DESCRIPTION
...instead of lists for the query args.
